### PR TITLE
Fix: GitHub Workflow trigger

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,5 +1,7 @@
 name: Spellcheck
-on: [push]
+on:
+  - push
+  - pull_request
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
GitHub Workflow was triggered only when push event was fired.
Now it is also triggered when pull_request event is fired.
This enables external contributors to run tests when they send pull requests.
(push event is fired when push is done to forked repository, but push event is not fired when push is done to kitsuyui's repository)
